### PR TITLE
Converted code to class-style so it can accept custom abbreviations.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,36 +1,37 @@
 (function(root){
-  'use strict';
+    'use strict';
+    
+    var NumberAbbreviate = function(abbrev) {
+	this.abbrev = abbrev == null ? ['k', 'm', 'b', 't'] : abbrev;
+    };
+    
+    NumberAbbreviate.prototype.abbreviate = function(number, decPlaces) {
+	decPlaces = Math.pow(10, decPlaces);
+	
+	for (var i = this.abbrev.length - 1; i>=0; i--) {
 
-  function numberAbbreviate(number, decPlaces) {
-    decPlaces = Math.pow(10, decPlaces)
+	    var size = Math.pow(10, (i + 1) * 3);
 
-    var abbrev = [ 'k', 'm', 'b', 't' ]
+	    if(size <= number) {
+		number = Math.round(number * decPlaces / size) / decPlaces;
 
-    for (var i = abbrev.length - 1; i>=0; i--) {
+		if((number === 1000) && (i < this.abbrev.length - 1)) {
+		    number = 1;
+		    i++;
+		}
 
-      var size = Math.pow(10, (i + 1) * 3)
+		number += this.abbrev[i];
 
-      if (size <= number) {
-        number = Math.round(number * decPlaces / size) / decPlaces
+		break;
+	    }
+	}
 
-        if ((number === 1000) && (i < abbrev.length - 1)) {
-          number = 1
-          i++
-        }
+	return number
+    };
 
-        number += abbrev[i]
-
-        break
-      }
+    if (typeof module !== 'undefined' && module.exports) {
+	module.exports = NumberAbbreviate;
+    } else {
+	root.NumberAbbreviate = NumberAbbreviate;
     }
-
-    return number
-  }
-
-  if (typeof module !== 'undefined' && module.exports) {
-    module.exports = numberAbbreviate;
-  } else {
-    root.numberAbbreviate = numberAbbreviate;
-  }
-
 })(this);

--- a/test.js
+++ b/test.js
@@ -1,18 +1,28 @@
-var numAbbr = require('./')
-  , assert = require('assert')
+var NumAbbr = require('./')
+, assert = require('assert');
 
 describe('number-abbreviate', function () {
 
-  it('should abbreviate numbers', function () {
-
-    assert.equal(numAbbr(12, 1), '12')
-    assert.equal(numAbbr(0, 2), '0')
-    assert.equal(numAbbr(1234, 0), '1k')
-    assert.equal(numAbbr(34567, 2), '34.57k')
-    assert.equal(numAbbr(918395, 1), '918.4k')
-    assert.equal(numAbbr(2134124, 2), '2.13m')
-    assert.equal(numAbbr(47475782130, 2), '47.48b')
-
-  })
-
-})
+    it('should abbreviate numbers', function () {
+	var numAbbr = new NumAbbr();
+	assert.equal(numAbbr.abbreviate(12, 1), '12');
+	assert.equal(numAbbr.abbreviate(0, 2), '0');
+	assert.equal(numAbbr.abbreviate(1234, 0), '1k');
+	assert.equal(numAbbr.abbreviate(34567, 2), '34.57k');
+	assert.equal(numAbbr.abbreviate(918395, 1), '918.4k');
+	assert.equal(numAbbr.abbreviate(2134124, 2), '2.13m');
+	assert.equal(numAbbr.abbreviate(47475782130, 2), '47.48b');
+	assert.equal(numAbbr.abbreviate(47475782130000, 2), '47.48t');
+    });
+    it('should abbreviate to digital units', function() {
+	var numAbbr = new NumAbbr(['KB', 'MB', 'GB', 'T']);
+	assert.equal(numAbbr.abbreviate(13, 1), '13');
+	assert.equal(numAbbr.abbreviate(0.0, 4), '0');
+	assert.equal(numAbbr.abbreviate(4398, 0), '4KB');
+	assert.equal(numAbbr.abbreviate(8192, 2), '8.19KB');
+	assert.equal(numAbbr.abbreviate(833124111, 3), '833.124MB');
+	assert.equal(numAbbr.abbreviate(833124111, 3), '833.124MB');
+	assert.equal(numAbbr.abbreviate(16000000000, 0), '16GB');
+	assert.equal(numAbbr.abbreviate(2120000000001, 2), '2.12T');
+    });
+});


### PR DESCRIPTION
Okay, sorry about that last attempt at a pull request; this one is good.

Changes include converting code to use a class instead of a function which allows for a custom list of abbreviations (e.g. "GB", "MB", "grand", etc).
