### PR TITLE
Add simpler shorthand interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ Abbreviate a number and add unit letters e.g. 2200000 => '2.2m'
 Code inspired by [http://stackoverflow.com/questions/2685911/is-there-a-way-to-round-numbers-into-a-reader-friendly-format-e-g-1-1k](http://stackoverflow.com/questions/2685911/is-there-a-way-to-round-numbers-into-a-reader-friendly-format-e-g-1-1k)
 
 ## Example
+Simple/shorthand mode:
+
+```js
+var abbreviate = require('number-abbreviate')
+abbreviate(1000) // => 1k
+abbreviate(1111, 0) // => 1k
+abbreviate(1111, 1) // => 1.1k
+abbreviate(1111, 2) // => 1.11k
+```
+
+Class/constructor mode:
 ``` js
   var NumAbbr = require('number-abbreviate')
 

--- a/index.js
+++ b/index.js
@@ -1,27 +1,37 @@
 (function(root){
   'use strict';
 
-  function NumberAbbreviate(abbrev) {
-    if (!(this instanceof NumberAbbreviate)) return new NumberAbbreviate(abbrev)
-    this.abbrev = abbrev == null ? ['k', 'm', 'b', 't'] : abbrev
+  function NumberAbbreviate() {
+    var units
+    if (!(this instanceof NumberAbbreviate)) {
+      // function usage: abbrev(n, decPlaces, units)
+      var n = arguments[0]
+      var decPlaces = arguments[1]
+      units = arguments[2]
+      var ab = new NumberAbbreviate(units)
+      return ab.abbreviate(n, decPlaces)
+    }
+    // class usage: new NumberAbbreviate(units)
+    units = arguments[0]
+    this.units = units == null ? ['k', 'm', 'b', 't'] : units
   }
 
   NumberAbbreviate.prototype._abbreviate = function(number, decPlaces) {
     decPlaces = Math.pow(10, decPlaces)
 
-    for (var i = this.abbrev.length - 1; i >= 0; i--) {
+    for (var i = this.units.length - 1; i >= 0; i--) {
 
       var size = Math.pow(10, (i + 1) * 3)
 
       if (size <= number) {
         number = Math.round(number * decPlaces / size) / decPlaces
 
-        if ((number === 1000) && (i < this.abbrev.length - 1)) {
+        if ((number === 1000) && (i < this.units.length - 1)) {
           number = 1
           i++
         }
 
-        number += this.abbrev[i]
+        number += this.units[i]
 
         break
       }

--- a/test.js
+++ b/test.js
@@ -39,11 +39,11 @@ describe('number-abbreviate', function () {
 
   })
 
-  it('should allow it to be called without `new`', function () {
+  it('calling the function without `new` enters shorthand mode', function () {
 
-    var numAbbr = numAbbrFn(['KB', 'MB', 'GB', 'T'])
-    assert.equal(numAbbr.abbreviate(13, 1), '13')
-    assert.equal(numAbbr.abbreviate(0.0, 4), '0')
+    assert.equal(numAbbrFn(13, 1, ['KB', 'MB', 'GB', 'T']), '13')
+    assert.equal(numAbbrFn(0.0, 4, ['KB', 'MB', 'GB', 'T']), '0')
+
 
   })
 


### PR DESCRIPTION
I'm using this module quite a lot a the moment… this was bugging me so much!

Pretty nasty way to flip modes, but I didn't want to throw away the interface to allow current users to upgrade without too much pain.

The only "breaking" change is that if anyone using the current class-based interface but wasn't using `new` will flip it into the simple mode.

So definitely a major version bump if you want to merge. Cheers!